### PR TITLE
DEPNotify

### DIFF
--- a/lib/facter/depnotify_running.rb
+++ b/lib/facter/depnotify_running.rb
@@ -2,10 +2,8 @@ Facter.add('depnotify_running') do
   confine osfamily: 'Darwin'
   setcode do
     depnotify_running = false
-    output = Facter::Util::Resolution.exec("/bin/ps axo pid,command | grep \"[D]EPNotify.app\"")
-    if $CHILD_STATUS.exitstatus === 0
-      depnotify_running = true
-    end
+    _ = Facter::Util::Resolution.exec('/bin/ps axo pid,command | grep "[D]EPNotify.app"')
+    depnotify_running = true if $CHILD_STATUS.exitstatus.zero?
     depnotify_running
   end
 end

--- a/lib/facter/depnotify_running.rb
+++ b/lib/facter/depnotify_running.rb
@@ -1,0 +1,11 @@
+Facter.add('depnotify_running') do
+  confine osfamily: 'Darwin'
+  setcode do
+    depnotify_running = false
+    output = Facter::Util::Resolution.exec("/bin/ps axo pid,command | grep \"[D]EPNotify.app\"")
+    if $CHILD_STATUS.exitstatus === 0
+      depnotify_running = true
+    end
+    depnotify_running
+  end
+end

--- a/lib/puppet/parser/functions/macos_package_installed.rb
+++ b/lib/puppet/parser/functions/macos_package_installed.rb
@@ -5,9 +5,9 @@ require 'puppet/util/package'
 
 # Returns true if the specified or newer version of the package is installed
 module Puppet::Parser::Functions
-  newfunction(:macos_package_installed, type: :rvalue, doc: <<-EOS
+  newfunction(:macos_package_installed, type: :rvalue, doc: <<-SOMEDOC
   Returns true if the specified or newer version of the package is installed.
-    EOS
+    SOMEDOC
              ) do |args|
     if args.size != 2
       raise(Puppet::ParseError, 'macos_package_installed(): ' \

--- a/manifests/depnotifycmd.pp
+++ b/manifests/depnotifycmd.pp
@@ -1,0 +1,10 @@
+# == Class: client_stdlib::depnotifycmd
+# Uses file_line to add the line to the end of the log
+# == Define: define_name
+#
+define client_stdlib::depnotifycmd (){
+  file_line {"DEPNotifyCmd ${name}":
+    path => '/var/tmp/depnotify.log'
+    line => $name
+  }
+}

--- a/manifests/depnotifycmd.pp
+++ b/manifests/depnotifycmd.pp
@@ -1,7 +1,6 @@
 # == Class: client_stdlib::depnotifycmd
 # Uses file_line to add the line to the end of the log
-# == Define: define_name
-#
+
 define client_stdlib::depnotifycmd (){
   file_line {"DEPNotifyCmd ${name}":
     path => '/var/tmp/depnotify.log'


### PR DESCRIPTION
A fact to determine whether DEPNotify is running, and a defined type to write to it's log. This allows you to update DEPNotify during your initial puppet run.